### PR TITLE
Supabase RLS 用マイグレーションを追加

### DIFF
--- a/supabase/README.md
+++ b/supabase/README.md
@@ -1,0 +1,36 @@
+# Supabase セットアップ手順（VisuMemo）
+
+このフォルダの SQL を **上から順に** 実行してください。
+- 0001_create_notes.sql
+- 0002_enable_rls_and_policies.sql
+- 0003_storage_thumbs_policies.sql
+
+## 事前準備
+1) Supabase プロジェクトを作成  
+2) Storage バケット `thumbs` を private で作成（ダッシュボード）  
+3) 右上「SQL Editor」で上記 3 ファイルを順に実行
+
+## 動作の考え方
+- RLS により、`public.notes` は **自分の user_id の行だけ**読める/書ける/更新できる/削除できる
+- Storage は `name = '{user_id}/{note_id}.jpg'` の規約を課すことで、
+  `storage.objects` のポリシーが「最初のフォルダ = 自分の UID」の場合だけ許可する
+
+## クライアント側の保存例（擬似コード）
+```ts
+// 1) Note を作成（user_id は default auth.uid() で自動）
+const { data: note } = await sb.from('notes')
+  .insert({ title, body, preview_text })
+  .select('id')
+  .single();
+
+// 2) サムネ JPEG を生成し、ユーザーID/ノートID でアップロード
+const uid = (await sb.auth.getUser()).data.user?.id!;
+const key = `${uid}/${note.id}.jpg`;
+await sb.storage.from('thumbs').upload(key, blob, { upsert: true });
+
+// 3) notes.thumb_path をキーで更新
+await sb.from('notes').update({
+  thumb_path: key,
+  thumb_updated_at: new Date().toISOString()
+}).eq('id', note.id);
+```

--- a/supabase/migrations/0001_create_notes.sql
+++ b/supabase/migrations/0001_create_notes.sql
@@ -1,3 +1,7 @@
+-- notes テーブル作成（ユーザー所有）
+-- ポイント: user_id は auth.users を参照し、既定値を auth.uid() にする
+create extension if not exists pgcrypto; -- gen_random_uuid 用（環境により不要）
+
 create table if not exists public.notes (
   id uuid primary key default gen_random_uuid(),
   user_id uuid not null references auth.users(id) on delete cascade,
@@ -12,3 +16,9 @@ create table if not exists public.notes (
 
 create index if not exists notes_user_idx on public.notes(user_id);
 
+-- 既存データに対して user_id の既定値を設定（今後の insert を簡略化）
+alter table public.notes
+  alter column user_id set default auth.uid();
+
+comment on table public.notes is 'ユーザー単位のメモ本体';
+comment on column public.notes.thumb_path is 'Storage 上のサムネイルパス（例: {user_id}/{note_id}.jpg）';

--- a/supabase/migrations/0002_enable_rls_and_policies.sql
+++ b/supabase/migrations/0002_enable_rls_and_policies.sql
@@ -1,0 +1,39 @@
+-- Row Level Security（RLS）を有効化し、自分の行だけ読み書きできるようにする
+
+-- RLS 有効化
+alter table public.notes enable row level security;
+
+-- 既存ポリシーがある場合に備えて削除（再適用のため）
+drop policy if exists "select own notes" on public.notes;
+drop policy if exists "insert own notes" on public.notes;
+drop policy if exists "update own notes" on public.notes;
+drop policy if exists "delete own notes" on public.notes;
+
+-- 自分のノートだけ読める
+create policy "select own notes"
+on public.notes
+for select
+to authenticated
+using (user_id = auth.uid());
+
+-- 自分のノートだけ挿入できる（auth.uid() が既定値だが、明示指定でもチェック）
+create policy "insert own notes"
+on public.notes
+for insert
+to authenticated
+with check (user_id = auth.uid());
+
+-- 自分のノートだけ更新できる
+create policy "update own notes"
+on public.notes
+for update
+to authenticated
+using (user_id = auth.uid())
+with check (user_id = auth.uid());
+
+-- 必要なら削除も制御（論理削除のみなら不要）
+create policy "delete own notes"
+on public.notes
+for delete
+to authenticated
+using (user_id = auth.uid());

--- a/supabase/migrations/0003_storage_thumbs_policies.sql
+++ b/supabase/migrations/0003_storage_thumbs_policies.sql
@@ -1,0 +1,54 @@
+-- Storage(thumbs) バケット用の RLS 相当ポリシー（storage.objects テーブルに対するポリシー）
+-- 想定パス: name = '{user_id}/{note_id}.jpg'
+-- 先頭フォルダを user_id にすることでユーザーごとに完全分離する
+
+-- バケットが未作成なら作成（ダッシュボードで作成済みならスキップ可）
+-- 注: Supabase CLI 環境でバケット作成はストレージAPI経由となるため、
+--     ここではポリシーのみ定義し、バケット作成はコンソール/CLIで行う運用を推奨。
+-- 例: バケット名 'thumbs' を private で作成
+
+-- 既存ポリシーをクリア（再実行に備える）
+drop policy if exists "read own thumbs" on storage.objects;
+drop policy if exists "write own thumbs" on storage.objects;
+drop policy if exists "update own thumbs" on storage.objects;
+drop policy if exists "delete own thumbs" on storage.objects;
+
+-- 自分のファイルだけ閲覧（サインドURL生成に必要）
+create policy "read own thumbs"
+on storage.objects
+for select
+to authenticated
+using (
+  bucket_id = 'thumbs'
+  and (storage.foldername(name))[1] = auth.uid()::text
+);
+
+-- 自分のフォルダ配下にだけアップロード可能
+create policy "write own thumbs"
+on storage.objects
+for insert
+to authenticated
+with check (
+  bucket_id = 'thumbs'
+  and (storage.foldername(name))[1] = auth.uid()::text
+);
+
+-- 自分のフォルダ配下にだけ更新可能
+create policy "update own thumbs"
+on storage.objects
+for update
+to authenticated
+using (
+  bucket_id = 'thumbs'
+  and (storage.foldername(name))[1] = auth.uid()::text
+);
+
+-- 自分のファイルだけ削除可能（必要に応じて）
+create policy "delete own thumbs"
+on storage.objects
+for delete
+to authenticated
+using (
+  bucket_id = 'thumbs'
+  and (storage.foldername(name))[1] = auth.uid()::text
+);


### PR DESCRIPTION
## 概要
- notes テーブルにユーザー所有のための既定値やコメントを追加
- notes テーブルの RLS ポリシーを整備
- Storage thumbs バケット用のポリシーと実行手順を README に記載
